### PR TITLE
Update to fs2 3.1.3

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,7 +1,7 @@
 import sbt._
 
 object Versions {
-  val fs2        = "3.0.6"
+  val fs2        = "3.1.3"
   val fs2Data    = "1.0.0"
   val enumeratum = "1.7.0"
 }

--- a/site/docs/documentation/file/index.md
+++ b/site/docs/documentation/file/index.md
@@ -14,12 +14,12 @@ This API lives in the `com.mobimeo.gtfs.file` package
 ```scala mdoc
 import com.mobimeo.gtfs.file._
 
+import fs2.io.file.Path
+
 import cats.effect._
 import cats.effect.unsafe.implicits.global
 
-import java.nio.file._
-
-GtfsFile[IO](Paths.get("site/gtfs.zip")).use { gtfs =>
+GtfsFile[IO](Path("site/gtfs.zip")).use { gtfs =>
   IO.pure(s"Some work with the GTFS file at ${gtfs.file}")
 }.unsafeRunSync()
 ```

--- a/site/docs/documentation/file/reading/index.md
+++ b/site/docs/documentation/file/reading/index.md
@@ -17,9 +17,9 @@ import com.mobimeo.gtfs.model._
 import cats.effect._
 import cats.effect.unsafe.implicits.global
 
-import java.nio.file._
+import fs2.io.file.Path
 
-val gtfs = GtfsFile[IO](Paths.get("site/gtfs.zip"))
+val gtfs = GtfsFile[IO](Path("site/gtfs.zip"))
 ```
 
 The acquired GTFS resource gives access to the content under the `read` namespace. The content is streamed entity by entity. This way the files are never entirely loaded into memory when reading them. The `read` namespace exposes function to read from the standard files, for instance if one wants to read the available route names from a GTFS file, on can use the `routes` function as follows. Note that it uses the [provided data model][gtfs-model].

--- a/site/docs/documentation/file/writing/index.md
+++ b/site/docs/documentation/file/writing/index.md
@@ -18,9 +18,9 @@ import com.mobimeo.gtfs.model._
 import cats.effect._
 import cats.effect.unsafe.implicits.global
 
-import java.nio.file._
+import fs2.io.file.{CopyFlag, CopyFlags, Path}
 
-val gtfs = GtfsFile[IO](Paths.get("site/gtfs.zip"))
+val gtfs = GtfsFile[IO](Path("site/gtfs.zip"))
 ```
 
 ## Modifying an existing file
@@ -42,9 +42,9 @@ This code modifies the file in place, making all stop names uppercase. However t
 One should prefer to work on a copy of the original file. The `GtfsFile` provides a way to do it conveniently.
 
 ```scala mdoc
-val modified = Paths.get("site/modified-gtfs.zip")
+val modified = Path("site/modified-gtfs.zip")
 gtfs.use { src =>
-  src.copyTo(modified, List(StandardCopyOption.REPLACE_EXISTING)).use { tgt =>
+  src.copyTo(modified, CopyFlags(CopyFlag.ReplaceExisting)).use { tgt =>
     src.read
       .rawStops
       .map(s => s.modify("stop_name")(_.toUpperCase))
@@ -82,7 +82,7 @@ If one wants to create a new file from scratch, one need to tell the file needs 
 def makeStop(id: String, name: String) =
   Stop(id, None, Some(name), None, None, None, None, None, None, None, None, None, None, None)
 
-val file = Paths.get("site/gtfs2.zip")
+val file = Path("site/gtfs2.zip")
 GtfsFile[IO](file, create = true).use { gtfs =>
   fs2.Stream.emits(List(makeStop("stop1", "Some Stop"), makeStop("stop2", "Some Other Stop")))
     .covary[IO]


### PR DESCRIPTION
This version deprecates using java.nio directly in favor of fs2 types.