### PR TITLE
Disable usage of sbt thin client

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,14 +50,14 @@ jobs:
           key: ${{ runner.os }}-sbt-cache-v2-${{ hashFiles('**/*.sbt') }}-${{ hashFiles('project/build.properties') }}
 
       - name: Check that workflows are up to date
-        run: sbt --client '++${{ matrix.scala }}; githubWorkflowCheck'
+        run: sbt ++${{ matrix.scala }} githubWorkflowCheck
 
       - name: Build project
-        run: sbt --client '++${{ matrix.scala }}; test'
+        run: sbt ++${{ matrix.scala }} test
 
       - name: Compile Documentation
         if: matrix.scala == '2.13.6'
-        run: sbt --client '++${{ matrix.scala }}; site/mdoc'
+        run: sbt ++${{ matrix.scala }} site/mdoc
 
       - name: Compress target directories
         run: tar cf targets.tar target core/target rules/target project/target
@@ -126,7 +126,7 @@ jobs:
           PGP_SECRET: ${{ secrets.PGP_SECRET }}
           SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
           SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
-        run: sbt --client '++${{ matrix.scala }}; ci-release'
+        run: sbt ++${{ matrix.scala }} ci-release
 
   site:
     name: Deploy site
@@ -161,7 +161,7 @@ jobs:
 
       - name: Compile Website
         if: matrix.scala == '2.13.6'
-        run: sbt --client '++${{ matrix.scala }}; site/makeMicrosite'
+        run: sbt ++${{ matrix.scala }} site/makeMicrosite
 
       - name: Deploy site
         uses: peaceiris/actions-gh-pages@v3

--- a/build.sbt
+++ b/build.sbt
@@ -58,6 +58,9 @@ ThisBuild / githubWorkflowPublish := Seq(
   )
 )
 
+// don't use sbt thin client
+ThisBuild / githubWorkflowUseSbtThinClient := false
+
 // publish website
 
 ThisBuild / githubWorkflowAddedJobs += WorkflowJob(
@@ -125,7 +128,7 @@ lazy val site = project
     libraryDependencies ++= Dependencies.site,
     scalacOptions ~= filterConsoleScalacOptions,
     mdocExtraArguments := Seq("--no-link-hygiene"),
-    githubWorkflowArtifactUpload := false
+    githubWorkflowArtifactUpload := false,
   )
   .dependsOn(core, rules)
 


### PR DESCRIPTION
The thin client can sometimes be flaky, let's not use it for now.