### PR TITLE
Make syntax parse `Pure` rules

### DIFF
--- a/rules/src/main/scala/com/mobimeo/gtfs/rules/Engine.scala
+++ b/rules/src/main/scala/com/mobimeo/gtfs/rules/Engine.scala
@@ -40,7 +40,7 @@ class Engine[F[_]](interpreter: Interpreter[F])(implicit
     * The order in which the files are processed is not specified (and can even be done in parallel) but the different
     * rule sets operating on a single file are ensured to be run in the same order as provided.
     */
-  def process(rulesets: List[RuleSet[F]], from: GtfsFile[F], to: GtfsFile[F], ctx: Ctx = Ctx.empty): F[Unit] = {
+  def process[G[x] <: F[x]](rulesets: List[RuleSet[G]], from: GtfsFile[F], to: GtfsFile[F], ctx: Ctx = Ctx.empty): F[Unit] = {
     // fusing rule sets allows to only go through the entities once
     // even if several rulesets are defined for a given file
     // this is possible because each ruleset consider the rows in isolation

--- a/rules/src/main/scala/com/mobimeo/gtfs/rules/Rule.scala
+++ b/rules/src/main/scala/com/mobimeo/gtfs/rules/Rule.scala
@@ -20,9 +20,9 @@ import cats.data.NonEmptyList
 import cats.Show
 import cats.syntax.all._
 
-case class RuleSet[F[_]](file: String, rules: List[Rule[F]], additions: List[NonEmptyList[String]])
+case class RuleSet[+F[_]](file: String, rules: List[Rule[F]], additions: List[NonEmptyList[String]])
 
-case class Rule[F[_]](name: String, matcher: Matcher, action: Action[F])
+case class Rule[+F[_]](name: String, matcher: Matcher, action: Action[F])
 
 sealed trait Matcher {
   def unary_! : Matcher =
@@ -83,18 +83,18 @@ object Value {
   }
 }
 
-sealed trait Action[F[_]]
+sealed trait Action[+F[_]]
 object Action {
 
   case class Delete[F[_]]() extends Action[F]
 
   case class Log[F[_]](msg: Expr[F], level: LogLevel) extends Action[F]
 
-  case class Transform[F[_]](transformations: NonEmptyList[Transformation[F]]) extends Action[F]
+  case class Transform[+F[_]](transformations: NonEmptyList[Transformation[F]]) extends Action[F]
 
 }
 
-sealed trait Transformation[F[_]]
+sealed trait Transformation[+F[_]]
 object Transformation {
 
   case class Set[F[_]](field: Value, to: Expr[F])                                     extends Transformation[F]
@@ -102,7 +102,7 @@ object Transformation {
 
 }
 
-sealed trait Expr[F[_]]
+sealed trait Expr[+F[_]]
 object Expr {
   case class NamedFunction[F[_]](name: String, args: List[Expr[F]])                     extends Expr[F]
   case class AnonymousFunction[F[_]](f: List[String] => F[String], args: List[Expr[F]]) extends Expr[F]

--- a/rules/syntax/src/main/scala-2/com/mobimeo/gtfs/rules/syntax/literals.scala
+++ b/rules/syntax/src/main/scala-2/com/mobimeo/gtfs/rules/syntax/literals.scala
@@ -2,21 +2,21 @@ package com.mobimeo.gtfs.rules.syntax
 
 import org.typelevel.literally.Literally
 import com.mobimeo.gtfs.rules._
-import cats.Id
 import cats.syntax.all._
 import cats.data.NonEmptyList
 import scala.annotation.unused
 import com.mobimeo.gtfs.rules
 import scala.reflect.macros.blackbox.Context
+import fs2.Pure
 
 object literals {
 
   implicit class RulesInterpolator(val sc: StringContext) extends AnyVal {
-    def ruleset(args: Any*): RuleSet[Id] = macro RuleSetLiteral.make
-    def rule(args: Any*): Rule[Id] = macro RuleLiteral.make
+    def ruleset(args: Any*): RuleSet[Pure] = macro RuleSetLiteral.make
+    def rule(args: Any*): Rule[Pure] = macro RuleLiteral.make
     def matcher(args: Any*): Matcher = macro MatcherLiteral.make
-    def action(args: Any*): Action[Id] = macro ActionLiteral.make
-    def transform(args: Any*): Transformation[Id] = macro TransformationLiteral.make
+    def action(args: Any*): Action[Pure] = macro ActionLiteral.make
+    def transform(args: Any*): Transformation[Pure] = macro TransformationLiteral.make
   }
 
   trait LiftableImpls {
@@ -58,11 +58,11 @@ object literals {
         q"_root_.com.mobimeo.gtfs.rules.Matcher.Or($left, $right)"
     }
 
-    implicit lazy val expr: Liftable[rules.Expr[Id]] = Liftable[rules.Expr[Id]] {
+    implicit lazy val expr: Liftable[rules.Expr[Pure]] = Liftable[rules.Expr[Pure]] {
       case rules.Expr.Val(v) =>
-        q"_root_.com.mobimeo.gtfs.rules.Expr.Val[_root_.cats.Id]($v)"
+        q"_root_.com.mobimeo.gtfs.rules.Expr.Val[_root_.fs2.Pure]($v)"
       case rules.Expr.NamedFunction(name, args) =>
-        q"_root_.com.mobimeo.gtfs.rules.Expr.NamedFunction[_root_.cats.Id]($name, $args)"
+        q"_root_.com.mobimeo.gtfs.rules.Expr.NamedFunction[_root_.fs2.Pure]($name, $args)"
       case rules.Expr.AnonymousFunction(_, _) =>
         c.abort(c.enclosingPosition, "anonymous functions are not supported")
     }
@@ -74,33 +74,33 @@ object literals {
       case LogLevel.Error   => q"_root_.com.mobimeo.gtfs.rules.LogLevel.Error"
     }
 
-    implicit lazy val transformation: Liftable[Transformation[Id]] = Liftable[Transformation[Id]] {
-      case Transformation.Set(v, e) => q"_root_.com.mobimeo.gtfs.rules.Transformation.Set[_root_.cats.Id]($v, $e): _root_.com.mobimeo.gtfs.rules.Transformation[_root_.cats.Id]"
+    implicit lazy val transformation: Liftable[Transformation[Pure]] = Liftable[Transformation[Pure]] {
+      case Transformation.Set(v, e) => q"_root_.com.mobimeo.gtfs.rules.Transformation.Set[_root_.fs2.Pure]($v, $e): _root_.com.mobimeo.gtfs.rules.Transformation[_root_.fs2.Pure]"
       case Transformation.SearchAndReplace(fld, re, repl) =>
-        q"_root_.com.mobimeo.gtfs.rules.Transformation.SearchAndReplace[_root_.cats.Id]($fld, $re, $repl): _root_.com.mobimeo.gtfs.rules.Transformation[_root_.cats.Id]"
+        q"_root_.com.mobimeo.gtfs.rules.Transformation.SearchAndReplace[_root_.fs2.Pure]($fld, $re, $repl): _root_.com.mobimeo.gtfs.rules.Transformation[_root_.fs2.Pure]"
     }
 
-    implicit lazy val action: Liftable[Action[Id]] = Liftable[Action[Id]] {
+    implicit lazy val action: Liftable[Action[Pure]] = Liftable[Action[Pure]] {
       case Action.Delete() =>
-        q"_root_.com.mobimeo.gtfs.rules.Action.Delete[_root_.cats.Id]()"
+        q"_root_.com.mobimeo.gtfs.rules.Action.Delete[_root_.fs2.Pure]()"
       case Action.Log(msg, lvl) =>
-        q"_root_.com.mobimeo.gtfs.rules.Action.Log[_root_.cats.Id]($msg, $lvl)"
+        q"_root_.com.mobimeo.gtfs.rules.Action.Log[_root_.fs2.Pure]($msg, $lvl)"
       case Action.Transform(ts) =>
-        q"_root_.com.mobimeo.gtfs.rules.Action.Transform[_root_.cats.Id]($ts)"
+        q"_root_.com.mobimeo.gtfs.rules.Action.Transform[_root_.fs2.Pure]($ts)"
     }
 
-    implicit lazy val rule: Liftable[Rule[Id]] = Liftable[Rule[Id]] { r =>
-      q"_root_.com.mobimeo.gtfs.rules.Rule[_root_.cats.Id](${r.name}, ${r.matcher}, ${r.action})"
+    implicit lazy val rule: Liftable[Rule[Pure]] = Liftable[Rule[Pure]] { r =>
+      q"_root_.com.mobimeo.gtfs.rules.Rule[_root_.fs2.Pure](${r.name}, ${r.matcher}, ${r.action})"
     }
 
-    implicit lazy val ruleset: Liftable[RuleSet[Id]] = Liftable[RuleSet[Id]] { r =>
-      q"_root_.com.mobimeo.gtfs.rules.RuleSet[_root_.cats.Id](${r.file}, ${r.rules}, ${r.additions})"
+    implicit lazy val ruleset: Liftable[RuleSet[Pure]] = Liftable[RuleSet[Pure]] { r =>
+      q"_root_.com.mobimeo.gtfs.rules.RuleSet[_root_.fs2.Pure](${r.file}, ${r.rules}, ${r.additions})"
     }
 
   }
 
-  private object RuleSetLiteral extends Literally[RuleSet[Id]] {
-    def validate(ctx: Context)(s: String): Either[String, ctx.Expr[RuleSet[Id]]] = {
+  private object RuleSetLiteral extends Literally[RuleSet[Pure]] {
+    def validate(ctx: Context)(s: String): Either[String, ctx.Expr[RuleSet[Pure]]] = {
       import ctx.universe._
       val liftables = new LiftableImpls {
         val c: ctx.type = ctx
@@ -112,11 +112,11 @@ object literals {
         .map(rs => ctx.Expr(q"$rs"))
     }
 
-    def make(c: Context)(args: c.Expr[Any]*): c.Expr[RuleSet[Id]] = apply(c)(args: _*)
+    def make(c: Context)(args: c.Expr[Any]*): c.Expr[RuleSet[Pure]] = apply(c)(args: _*)
   }
 
-  private object RuleLiteral extends Literally[Rule[Id]] {
-    def validate(ctx: Context)(s: String): Either[String, ctx.Expr[Rule[Id]]] = {
+  private object RuleLiteral extends Literally[Rule[Pure]] {
+    def validate(ctx: Context)(s: String): Either[String, ctx.Expr[Rule[Pure]]] = {
       import ctx.universe._
       val liftables = new LiftableImpls {
         val c: ctx.type = ctx
@@ -129,7 +129,7 @@ object literals {
         .map(r => ctx.Expr(q"$r"))
     }
 
-    def make(c: Context)(args: c.Expr[Any]*): c.Expr[Rule[Id]] = apply(c)(args: _*)
+    def make(c: Context)(args: c.Expr[Any]*): c.Expr[Rule[Pure]] = apply(c)(args: _*)
   }
 
   private object MatcherLiteral extends Literally[Matcher] {
@@ -149,8 +149,8 @@ object literals {
     def make(c: Context)(args: c.Expr[Any]*): c.Expr[Matcher] = apply(c)(args: _*)
   }
 
-  private object TransformationLiteral extends Literally[Transformation[Id]] {
-    def validate(ctx: Context)(s: String): Either[String, ctx.Expr[Transformation[Id]]] = {
+  private object TransformationLiteral extends Literally[Transformation[Pure]] {
+    def validate(ctx: Context)(s: String): Either[String, ctx.Expr[Transformation[Pure]]] = {
       import ctx.universe._
       val liftables = new LiftableImpls {
         val c: ctx.type = ctx
@@ -163,11 +163,11 @@ object literals {
         .map(m => c.Expr(q"$m"))
     }
 
-    def make(c: Context)(args: c.Expr[Any]*): c.Expr[Transformation[Id]] = apply(c)(args: _*)
+    def make(c: Context)(args: c.Expr[Any]*): c.Expr[Transformation[Pure]] = apply(c)(args: _*)
   }
 
-  private object ActionLiteral extends Literally[Action[Id]] {
-    def validate(ctx: Context)(s: String): Either[String, ctx.Expr[Action[Id]]] = {
+  private object ActionLiteral extends Literally[Action[Pure]] {
+    def validate(ctx: Context)(s: String): Either[String, ctx.Expr[Action[Pure]]] = {
       import ctx.universe._
       val liftables = new LiftableImpls {
         val c: ctx.type = ctx
@@ -180,7 +180,7 @@ object literals {
         .map(m => c.Expr(q"$m"))
     }
 
-    def make(c: Context)(args: c.Expr[Any]*): c.Expr[Action[Id]] = apply(c)(args: _*)
+    def make(c: Context)(args: c.Expr[Any]*): c.Expr[Action[Pure]] = apply(c)(args: _*)
   }
 
 }

--- a/rules/syntax/src/main/scala-3/com/mobimeo/gtfs/rules/syntax/literals.scala
+++ b/rules/syntax/src/main/scala-3/com/mobimeo/gtfs/rules/syntax/literals.scala
@@ -16,25 +16,25 @@
 
 package com.mobimeo.gtfs.rules.syntax
 
-import cats.Id
 import cats.syntax.all._
 import com.mobimeo.gtfs.rules._
 import org.typelevel.literally.Literally
 import scala.quoted.{Expr => QExpr, *}
 import cats.data.NonEmptyList
+import fs2.Pure
 
 object literals {
 
   extension (inline ctx: StringContext) {
-    inline def ruleset(inline args: Any*): RuleSet[Id] =
+    inline def ruleset(inline args: Any*): RuleSet[Pure] =
       ${ RuleSetLiteral('ctx, 'args) }
-    inline def rule(inline args: Any*): Rule[Id] =
+    inline def rule(inline args: Any*): Rule[Pure] =
       ${ RuleLiteral('ctx, 'args) }
     inline def matcher(inline args: Any*): Matcher =
       ${ MatcherLiteral('ctx, 'args) }
-    inline def action(inline args: Any*): Action[Id] =
+    inline def action(inline args: Any*): Action[Pure] =
       ${ ActionLiteral('ctx, 'args) }
-    inline def transform(inline args: Any*): Transformation[Id] =
+    inline def transform(inline args: Any*): Transformation[Pure] =
       ${ TransformationLiteral('ctx, 'args) }
   }
 
@@ -73,8 +73,8 @@ object literals {
     }
   }
 
-  given ToExpr[Expr[Id]] with {
-    def apply(e: Expr[Id])(using Quotes) = e match {
+  given ToExpr[Expr[Pure]] with {
+    def apply(e: Expr[Pure])(using Quotes) = e match {
       case Expr.Val(v)                    => '{ Expr.Val(${ QExpr(v) }) }
       case Expr.NamedFunction(name, args) => '{ Expr.NamedFunction(${ QExpr(name) }, ${ QExpr(args) }) }
       case Expr.AnonymousFunction(_, _)   => '{ compiletime.error("anonymous functions not supported") }
@@ -90,33 +90,33 @@ object literals {
     }
   }
 
-  given ToExpr[Transformation[Id]] with {
-    def apply(t: Transformation[Id])(using Quotes) = t match {
+  given ToExpr[Transformation[Pure]] with {
+    def apply(t: Transformation[Pure])(using Quotes) = t match {
       case Transformation.Set(fld, e) => '{ Transformation.Set(${ QExpr(fld) }, ${ QExpr(e) }) }
       case Transformation.SearchAndReplace(fld, re, repl) =>
         '{ Transformation.SearchAndReplace(${ QExpr(fld) }, ${ QExpr(re) }, ${ QExpr(repl) }) }
     }
   }
 
-  given ToExpr[Action[Id]] with {
-    def apply(a: Action[Id])(using Quotes) = a match {
+  given ToExpr[Action[Pure]] with {
+    def apply(a: Action[Pure])(using Quotes) = a match {
       case Action.Delete()      => '{ Action.Delete() }
       case Action.Log(msg, lvl) => '{ Action.Log(${ QExpr(msg) }, ${ QExpr(lvl) }) }
       case Action.Transform(ts) => '{ Action.Transform(${ QExpr(ts) }) }
     }
   }
 
-  given ToExpr[Rule[Id]] with {
-    def apply(r: Rule[Id])(using Quotes) =
+  given ToExpr[Rule[Pure]] with {
+    def apply(r: Rule[Pure])(using Quotes) =
       '{ Rule(${ QExpr(r.name) }, ${ QExpr(r.matcher) }, ${ QExpr(r.action) }) }
   }
 
-  given ToExpr[RuleSet[Id]] with {
-    def apply(r: RuleSet[Id])(using Quotes) =
+  given ToExpr[RuleSet[Pure]] with {
+    def apply(r: RuleSet[Pure])(using Quotes) =
       '{ RuleSet(${ QExpr(r.file) }, ${ QExpr(r.rules) }, ${ QExpr(r.additions) }) }
   }
 
-  object RuleSetLiteral extends Literally[RuleSet[Id]] {
+  object RuleSetLiteral extends Literally[RuleSet[Pure]] {
     def validate(s: String)(using Quotes) =
       RuleParser.ruleset
         .parseAll(s)
@@ -124,7 +124,7 @@ object literals {
         .map(r => Expr(r))
   }
 
-  object RuleLiteral extends Literally[Rule[Id]] {
+  object RuleLiteral extends Literally[Rule[Pure]] {
     def validate(s: String)(using Quotes) =
       RuleParser.rule
         .parseAll(s)
@@ -140,7 +140,7 @@ object literals {
         .map(r => Expr(r))
   }
 
-  object ActionLiteral extends Literally[Action[Id]] {
+  object ActionLiteral extends Literally[Action[Pure]] {
     def validate(s: String)(using Quotes) =
       RuleParser.action
         .parseAll(s)
@@ -148,7 +148,7 @@ object literals {
         .map(r => Expr(r))
   }
 
-  object TransformationLiteral extends Literally[Transformation[Id]] {
+  object TransformationLiteral extends Literally[Transformation[Pure]] {
     def validate(s: String)(using Quotes) =
       RuleParser.transformation
         .parseAll(s)

--- a/rules/syntax/src/main/scala/com/mobimeo/gtfs/rules/syntax/pretty.scala
+++ b/rules/syntax/src/main/scala/com/mobimeo/gtfs/rules/syntax/pretty.scala
@@ -18,8 +18,9 @@ package com.mobimeo.gtfs.rules.syntax
 
 import com.mobimeo.gtfs.rules._
 
-import cats.{Id, Show}
+import cats.Show
 import cats.syntax.all._
+import fs2.Pure
 
 /** Pretty prints rules in the concrete syntax.
   * '''Note: ''' anonymous functions cannot be rendered as then include scala code. Instances are printed as concatenation of the arguments.
@@ -62,7 +63,7 @@ object pretty {
       }
   }
 
-  implicit val expr: Show[Expr[Id]] =
+  implicit val expr: Show[Expr[Pure]] =
     Show.show {
       case Expr.NamedFunction(name, args)  => show"$name(${args.mkString_(", ")})"
       case Expr.AnonymousFunction(_, args) => args.mkString_(" + ")
@@ -82,14 +83,14 @@ object pretty {
     }
   }
 
-  implicit val transformation: Show[Transformation[Id]] = Show.show {
+  implicit val transformation: Show[Transformation[Pure]] = Show.show {
     case Transformation.Set(fld, e) =>
       show"set row[$fld] to $e"
     case Transformation.SearchAndReplace(fld, re, repl) =>
       show"""search $re in row[$fld] and replace by "${escapeString(repl)}"""""
   }
 
-  implicit val action: Show[Action[Id]] = Show.show {
+  implicit val action: Show[Action[Pure]] = Show.show {
     case Action.Delete()                 => "delete"
     case Action.Log(e, LogLevel.Debug)   => show"debug($e)"
     case Action.Log(e, LogLevel.Info)    => show"info($e)"
@@ -98,14 +99,14 @@ object pretty {
     case Action.Transform(ts)            => show"${ts.mkString_("\n  then ")}"
   }
 
-  implicit val rule: Show[Rule[Id]] = Show.show { r =>
+  implicit val rule: Show[Rule[Pure]] = Show.show { r =>
     show"""rule ${r.name} {
           |  when ${r.matcher}
           |  then ${r.action}
           |}""".stripMargin
   }
 
-  implicit val ruleset: Show[RuleSet[Id]] = Show.show { rs =>
+  implicit val ruleset: Show[RuleSet[Pure]] = Show.show { rs =>
     show"""ruleset for ${rs.file.dropRight(4)} {
           |  ${rs.rules.map(_.show.replace("\n", "\n  ")).mkString_("\n  or\n  ")}
           |}""".stripMargin

--- a/site/docs/documentation/rules/dsl/external/index.md
+++ b/site/docs/documentation/rules/dsl/external/index.md
@@ -98,7 +98,7 @@ There are two way to parse rules written with the external DSL:
  1. Using the `RuleParser` combinators from the `com.mobimeo.gtfs.rules.syntax` package.
  2. Using the string interpolators provided in the `com.mobimeo.gtfs.rules.syntax.lexicals` package.
 
-**Note:** Rules parsed with the external DSL are effect free, only rules with [`Id`][cats-id] are generated. The effectful rules only come from the ones using anonymous scala functions, which cannot be expressed with the DSL.
+**Note:** Rules parsed with the external DSL are effect free, only `Pure` rules are generated. The effectful rules only come from the ones using anonymous scala functions, which cannot be expressed with the DSL.
 
 ### Using the `RuleParser` class directly
 
@@ -178,12 +178,12 @@ rules.show
 **Note:** the concrete syntax does not allow for expressing anonymous functions. If you try to serialize rules containing calls to anonymous functions, it will be rendered as concatenation of the arguments.
 
 ```scala mdoc
-import cats.Id
+import fs2.Pure
 import com.mobimeo.gtfs.rules._
 
-val fun = (s: List[String]) => s.mkString("-")
+val fun = (s: List[String]) => ???
 
-val t: Expr[Id] = Expr.AnonymousFunction[Id](fun,
+val t: Expr[Pure] = Expr.AnonymousFunction[Pure](fun,
   List(
     Expr.Val(Value.Str("a")),
     Expr.Val(Value.Str("b")),
@@ -193,4 +193,3 @@ t.show
 ```
 
 [cats-parse]: https://github.com/typelevel/cats-parse
-[cats-id]: https://typelevel.org/cats/api/cats/index.html#Id[A]=A


### PR DESCRIPTION
This makes it easier to pass the rules to an engine with any effect
type, since `Pure` is actually `Nothing`, i.e. a sub type of anything.
Making the rule effect type covariant, these rules are handled out of
the box.